### PR TITLE
Style profile intro as standalone hero section

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -30,9 +30,9 @@ const dateToInput = $("#date-to");
 const dateClearBtn = $("#date-clear");
 
 // intro elements (filled from /api/site)
-const introTitle = document.querySelector("header .intro h1");
-const introDesc = document.querySelector("header .intro .muted");
-const introAvatar = document.querySelector("header .intro .avatar");
+const introTitle = document.querySelector(".profile-section .intro h1");
+const introDesc = document.querySelector(".profile-section .intro .muted");
+const introAvatar = document.querySelector(".profile-section .intro .avatar");
 
 year.textContent = new Date().getFullYear();
 
@@ -149,6 +149,12 @@ function renderTagBar(allTags) {
     };
     tagBar.appendChild(btn);
   });
+  const chipH = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--chip-h')) || 34;
+  const needToggle = tagBar.scrollHeight > chipH;
+  if (tagToggle) {
+    tagToggle.style.display = needToggle ? "" : "none";
+  }
+  state.tagsExpanded = needToggle ? state.tagsExpanded : true;
   applyTagCollapse();
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -8,37 +8,43 @@
   <link rel="stylesheet" href="/static/styles.css"/>
 </head>
 <body>
-  <header class="site-header container">
-    <div class="intro">
-      <img class="avatar" src="/static/me.jpg" alt="Shawn">
-      <div>
-        <h1>Shawn</h1>
-        <p class="muted">Senior Technical Product Specialist. Sharing photos, notes, videos, and interesting links.</p>
-        <div id="tagbar-wrap" class="tagbar-wrap collapsed">
-  <div id="tag-bar" class="tags"></div>
-  <button id="tag-toggle" class="chip chip-ghost" aria-expanded="false" type="button">More</button>
-</div>
+  <section class="profile-section">
+    <div class="container">
+      <div class="intro">
+        <img class="avatar" src="/static/me.jpg" alt="Shawn">
+        <div>
+          <h1>Shawn</h1>
+          <p class="muted">Senior Technical Product Specialist. Sharing photos, notes, videos, and interesting links.</p>
+        </div>
       </div>
     </div>
+  </section>
 
-<div class="toolbar">
-  <input id="search" type="search" placeholder="Search posts… (title, text, tags)" />
-  <div class="chips">
-    <button class="chip" data-type="all">All</button>
-    <button class="chip" data-type="photo">Photos</button>
-    <button class="chip" data-type="video">Videos</button>
-    <button class="chip" data-type="text">Text</button>
-    <button class="chip" data-type="link">Links</button>
-  </div>
+  <header class="site-header">
+    <div class="container">
+      <div class="toolbar">
+        <input id="search" type="search" placeholder="Search posts… (title, text, tags)" />
+        <div class="chips">
+          <button class="chip" data-type="all">All</button>
+          <button class="chip" data-type="photo">Photos</button>
+          <button class="chip" data-type="video">Videos</button>
+          <button class="chip" data-type="text">Text</button>
+          <button class="chip" data-type="link">Links</button>
+        </div>
 
-  <!-- NEW: Date filter -->
-  <div class="date-filter">
-    <label>From <input id="date-from" type="date"></label>
-    <span>–</span>
-    <label>To <input id="date-to" type="date"></label>
-    <button id="date-clear" class="chip chip-ghost" type="button">Clear</button>
-  </div>
-</div>
+        <!-- NEW: Date filter -->
+        <div class="date-filter">
+          <label>From <input id="date-from" type="date"></label>
+          <span>–</span>
+          <label>To <input id="date-to" type="date"></label>
+          <button id="date-clear" class="chip chip-ghost" type="button">Clear</button>
+        </div>
+      </div>
+      <div id="tagbar-wrap" class="tagbar-wrap collapsed">
+        <div id="tag-bar" class="tags"></div>
+        <button id="tag-toggle" class="chip chip-ghost" aria-expanded="false" type="button">More</button>
+      </div>
+    </div>
   </header>
 
   <main class="container">

--- a/static/styles.css
+++ b/static/styles.css
@@ -25,7 +25,14 @@ body{
 
 
 /* Header visual polish */
-.site-header{ padding: 28px 0 10px; }
+.profile-section{
+  background: linear-gradient(135deg, var(--panel) 0%, var(--panel-2) 100%);
+  padding: 40px 0;
+  box-shadow: var(--shadow);
+  border-bottom: 1px solid #1b2430;
+  margin-bottom: 24px;
+}
+.site-header{ padding: 20px 0 10px; }
 .intro{
   display: grid;
   grid-template-columns: 104px 1fr; /* larger avatar */
@@ -102,9 +109,10 @@ body{
   white-space: nowrap;
 }
 .tagbar-wrap.collapsed .tags{
-  max-height: var(--chip-h);
+  max-height: calc(var(--chip-h) + 4px);
   overflow: hidden;
   position: relative;
+  padding: 2px 0;
   /* fade-out on the right to hint there’s more */
   -webkit-mask-image: linear-gradient(to right, black calc(100% - 60px), transparent);
           mask-image: linear-gradient(to right, black calc(100% - 60px), transparent);


### PR DESCRIPTION
## Summary
- Move avatar and intro text into a dedicated hero section
- Add gradient background and shadow styling for the hero profile block
- Adjust header markup to contain only post toolbar
- Update intro element selectors in app.js to match hero markup and prevent null reference
- Relocate tag filter bar beneath search and date controls for clearer navigation
- Prevent tag chips from clipping when active and hide More/Less toggle when one row fits

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5f533d54c832a98d35a70a19a7790