### PR TITLE
refine intro section layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -26,21 +26,19 @@ body{
 
 /* Header visual polish */
 .profile-section{
-  background: linear-gradient(135deg, var(--panel) 0%, var(--panel-2) 100%);
   padding: 40px 0;
-  box-shadow: var(--shadow);
   border-bottom: 1px solid #1b2430;
-  margin-bottom: 24px;
+  margin-bottom: 8px;
 }
-.site-header{ padding: 20px 0 10px; }
+.site-header{ padding: 12px 0 10px; }
 .intro{
   display: grid;
-  grid-template-columns: 104px 1fr; /* larger avatar */
-  gap: 18px;
+  grid-template-columns: 120px 1fr; /* avatar column */
+  gap: 24px;
   align-items: center;
 }
 .avatar{
-  width: 104px; height: 104px; border-radius: 50%;
+  width: 120px; height: 120px; border-radius: 50%;
   object-fit: cover;
   border: 2px solid #18202c;
   box-shadow:
@@ -49,7 +47,7 @@ body{
     0 14px 28px rgba(0,0,0,.45);       /* soft drop */
 }
 .intro h1{
-  margin: 0 0 4px 0;
+  margin: 0 0 2px 0;
   font-size: clamp(22px, 2vw + 14px, 32px);
   letter-spacing: -0.01em;
   font-weight: 800;
@@ -58,6 +56,7 @@ body{
   color: var(--muted);
   max-width: 70ch;
   line-height: 1.55;
+  margin: 4px 0 0;
 }
 .muted{ color: var(--muted); }
 


### PR DESCRIPTION
## Summary
- tweak profile intro section styling to remove panel background and tighten spacing from filters
- enlarge avatar layout for added breathing room, adjust title spacing, and trim description margin

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5fa744024832aac89465679099306