### PR TITLE
Refine intro section layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -31,17 +31,15 @@ body {
 
 /* Header and toolbar */
 .profile-section {
-  background: linear-gradient(135deg, var(--panel) 0%, var(--panel-2) 100%);
   padding: 40px 0;
-  box-shadow: var(--shadow);
   border-bottom: 1px solid #1b2430;
-  margin-bottom: 24px;
+  margin-bottom: 8px;
 }
-.site-header { padding: 20px 0 10px; }
+.site-header { padding: 8px 0 10px; }
 .intro {
   display: grid;
   grid-template-columns: 104px 1fr; /* larger avatar */
-  gap: 18px;
+  gap: 24px;
   align-items: center;
 }
 .avatar {
@@ -54,7 +52,7 @@ body {
     0 14px 28px rgba(0,0,0,.45);       /* soft drop */
 }
 .intro h1 {
-  margin: 0 0 4px 0;
+  margin: 0 0 2px 0;
   font-size: clamp(22px, 2vw + 14px, 32px);
   letter-spacing: -0.01em;
   font-weight: 800;
@@ -67,7 +65,7 @@ body {
 
 /* Toolbar */
 .toolbar {
-  margin-top: 18px;
+  margin-top: 4px;
   display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
 }
 #search {


### PR DESCRIPTION
## Summary
- Remove background and shadow from the intro block and tighten spacing to search filters
- Give the profile photo more breathing room and tighten title-to-description spacing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5fd6cb534832a95b49cd97e7ac127