### PR TITLE
Limit tag bar to 10 tags with toggle

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -23,7 +23,6 @@ const modal = $("#modal");
 const modalBody = $("#modal-body");
 const year = $("#year");
 
-const tagWrap = $("#tagbar-wrap");
 const tagToggle = $("#tag-toggle");
 const dateFromInput = $("#date-from");
 const dateToInput = $("#date-to");
@@ -121,10 +120,14 @@ function buildVideoThumb(id, title) {
 }
 
 // ---------- tag utilities ----------
+const TAG_LIMIT = 10;
 
 function applyTagCollapse() {
-  if (!tagWrap) return;
-  tagWrap.classList.toggle("collapsed", !state.tagsExpanded);
+  if (!tagBar) return;
+  const tags = $$(".chip", tagBar);
+  tags.forEach((btn, idx) => {
+    btn.style.display = state.tagsExpanded || idx < TAG_LIMIT ? "" : "none";
+  });
   if (tagToggle) {
     tagToggle.textContent = state.tagsExpanded ? "Less" : "More";
     tagToggle.setAttribute("aria-expanded", String(state.tagsExpanded));
@@ -149,8 +152,7 @@ function renderTagBar(allTags) {
     };
     tagBar.appendChild(btn);
   });
-  const chipH = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--chip-h')) || 34;
-  const needToggle = tagBar.scrollHeight > chipH;
+  const needToggle = allTags.length > TAG_LIMIT;
   if (tagToggle) {
     tagToggle.style.display = needToggle ? "" : "none";
   }

--- a/static/index.html
+++ b/static/index.html
@@ -40,7 +40,7 @@
           <button id="date-clear" class="chip chip-ghost" type="button">Clear</button>
         </div>
       </div>
-      <div id="tagbar-wrap" class="tagbar-wrap collapsed">
+      <div id="tagbar-wrap" class="tagbar-wrap">
         <div id="tag-bar" class="tags"></div>
         <button id="tag-toggle" class="chip chip-ghost" aria-expanded="false" type="button">More</button>
       </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -108,16 +108,6 @@ body {
   font-size: 12px;
   white-space: nowrap;
 }
-.tagbar-wrap.collapsed .tags {
-  max-height: calc(var(--chip-h) + 4px);
-  overflow: hidden;
-  position: relative;
-  padding: 2px 0;
-  /* fade-out on the right to hint there’s more */
-  -webkit-mask-image: linear-gradient(to right, black calc(100% - 60px), transparent);
-          mask-image: linear-gradient(to right, black calc(100% - 60px), transparent);
-}
-
 /* Toggle button style */
 .chip-ghost {
   background: transparent;


### PR DESCRIPTION
## Summary
- Hard-code tag bar to show up to 10 tags and hide extras until expanded
- Remove overflow-measurement logic and collapsed styling
- Simplify tag bar markup and CSS

## Testing
- `node --check static/app.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b68e7ff21c832aafbda3a54250a17c