### PR TITLE
Limit tag bar to top 10 tags

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -40,10 +40,7 @@
           <button id="date-clear" class="chip chip-ghost" type="button">Clear</button>
         </div>
       </div>
-      <div id="tagbar-wrap" class="tagbar-wrap collapsed">
-        <div id="tag-bar" class="tags"></div>
-        <button id="tag-toggle" class="chip chip-ghost" aria-expanded="false" type="button">More</button>
-      </div>
+      <div id="tag-bar" class="tags"></div>
     </div>
   </header>
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -90,15 +90,17 @@ body {
 }
 .chip.active { outline: 2px solid var(--brand); }
 
-.tagbar-wrap {
+#tag-bar {
   margin-top: 12px;
-  position: relative;
   display: grid;
-  grid-template-columns: 1fr auto; /* tags + toggle button */
-  gap: 8px;
-  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 6px;
 }
 .tags { display: flex; gap: 6px; flex-wrap: wrap; }
+#tag-bar .chip {
+  width: 100%;
+  text-align: center;
+}
 .tag {
   background: #0f1722;
   border: 1px solid #1b2430;
@@ -108,16 +110,6 @@ body {
   font-size: 12px;
   white-space: nowrap;
 }
-.tagbar-wrap.collapsed .tags {
-  max-height: calc(var(--chip-h) + 4px);
-  overflow: hidden;
-  position: relative;
-  padding: 2px 0;
-  /* fade-out on the right to hint there’s more */
-  -webkit-mask-image: linear-gradient(to right, black calc(100% - 60px), transparent);
-          mask-image: linear-gradient(to right, black calc(100% - 60px), transparent);
-}
-
 /* Toggle button style */
 .chip-ghost {
   background: transparent;


### PR DESCRIPTION
## Summary
- Display only the top 10 most-used tags, sorted by frequency
- Remove tag bar toggle and collapse logic
- Lay out tag buttons in a responsive grid that fills available width

## Testing
- `node --check static/app.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b68e7ff21c832aafbda3a54250a17c