### PR TITLE
feat: show gallery indicator on photo cards

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -178,6 +178,11 @@ function renderCard(post) {
     img.src = src;
     img.alt = post.title || "photo";
     thumb.appendChild(img);
+    if (post.urls && post.urls.length > 1) {
+      const badge = document.createElement("div");
+      badge.className = "gallery-badge";
+      thumb.appendChild(badge);
+    }
   } else if (post.type === "video") {
     const id = isYouTube(post.url);
     if (id) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -158,11 +158,38 @@ body {
   background: #0f1520;
   display: grid;
   place-items: center;
+  position: relative;
 }
 .card .thumb img {
   width: 100%;
   height: auto;             /* natural aspect ratio */
   display: block;
+}
+
+.gallery-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 18px;
+  height: 18px;
+}
+.gallery-badge::before,
+.gallery-badge::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: rgba(0,0,0,.45);
+  border: 1px solid rgba(255,255,255,.85);
+  border-radius: 2px;
+}
+.gallery-badge::before {
+  top: 3px;
+  left: 3px;
+}
+.gallery-badge::after {
+  top: 0;
+  left: 0;
 }
 
 /* Link cards – image on top, text underneath */


### PR DESCRIPTION
## Summary
- mark photo cards with a gallery badge when multiple images are present
- style the badge with stacked-square icon overlay

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6e08edb74832ab9acb1f49b0c13b6