### PR TITLE
Add configurable site branding and user menu

### DIFF
--- a/posts/site.json
+++ b/posts/site.json
@@ -1,5 +1,6 @@
 {
-  "title": "John Doe",
-  "description": "A personal page, just for me. This is all about my hobbies, thoughts, and ADHD fueled late night internet browsing habits. If you've been missing me, drop in to see what I've been up to.",
-  "avatar": "/static/uploads/Screenshot_2025-02-14_095008.png"
+  "title": "Antisocial",
+  "logo": "",
+  "favicon": "",
+  "tab_text": "Antisocial"
 }

--- a/server.py
+++ b/server.py
@@ -56,9 +56,10 @@ def save_posts(posts):
 
 def load_site():
     return load_json(SITE_FILE, {
-        "title": "Shawn",
-        "description": "Senior Technical Product Specialist. Sharing photos, notes, videos, and interesting links.",
-        "avatar": "/static/me.jpg"
+        "title": "Antisocial",
+        "logo": None,
+        "favicon": None,
+        "tab_text": "Antisocial",
     })
 
 def save_site(site):
@@ -307,7 +308,7 @@ def api_update_site():
         return make_response(("Unauthorized", 401))
     body = request.get_json(force=True, silent=True) or {}
     site = load_site()
-    for k in ["title", "description", "avatar"]:
+    for k in ["title", "logo", "favicon", "tab_text"]:
         if k in body:
             site[k] = body[k]
     save_site(site)

--- a/static/admin.html
+++ b/static/admin.html
@@ -131,19 +131,27 @@
 
     <!-- Collapsed by default -->
     <details class="panel collapsible" id="site-panel">
-      <summary><h2>Site Profile</h2> <span class="muted">— title, description, avatar</span></summary>
+      <summary><h2>Site</h2> <span class="muted">— logo, favicon, title</span></summary>
       <div class="content">
         <div class="row"><label>Title</label><input id="site-title" type="text"/></div>
-        <div class="row"><label>Description</label><textarea id="site-desc"></textarea></div>
+        <div class="row"><label>Tab Text</label><input id="site-tab" type="text"/></div>
         <div class="row">
-          <label>Avatar URL</label>
+          <label>Logo URL</label>
           <div class="flex">
-            <input id="site-avatar" type="text" placeholder="/static/me.jpg or https://…"/>
-            <input id="avatar-file" type="file" accept="image/*"/>
-            <button class="btn" id="upload-avatar">Upload & use</button>
+            <input id="site-logo" type="text" placeholder="/static/logo.png or https://…"/>
+            <input id="logo-file" type="file" accept="image/*"/>
+            <button class="btn" id="upload-logo">Upload & use</button>
           </div>
         </div>
-        <button class="btn" id="save-site">Save Profile</button>
+        <div class="row">
+          <label>Favicon URL</label>
+          <div class="flex">
+            <input id="site-favicon" type="text" placeholder="/static/favicon.ico or https://…"/>
+            <input id="favicon-file" type="file" accept="image/*"/>
+            <button class="btn" id="upload-favicon">Upload & use</button>
+          </div>
+        </div>
+        <button class="btn" id="save-site">Save Site</button>
       </div>
     </details>
 

--- a/static/admin.js
+++ b/static/admin.js
@@ -30,10 +30,13 @@
 
   // ====== DOM elements ======
   const siteTitle   = $('#site-title');
-  const siteDesc    = $('#site-desc');
-  const siteAvatar  = $('#site-avatar');
-  const avatarFile  = $('#avatar-file');
-  const uploadAvatarBtn = $('#upload-avatar');
+  const siteTab     = $('#site-tab');
+  const siteLogo    = $('#site-logo');
+  const siteFavicon = $('#site-favicon');
+  const logoFile    = $('#logo-file');
+  const faviconFile = $('#favicon-file');
+  const uploadLogoBtn = $('#upload-logo');
+  const uploadFaviconBtn = $('#upload-favicon');
 
   const pTitle = $('#p-title');
   const pText  = $('#p-text');
@@ -213,25 +216,37 @@
     try{
       await putJSON('/api/site', {
         title: siteTitle.value.trim(),
-        description: siteDesc.value.trim(),
-        avatar: siteAvatar.value.trim()
+        tab_text: siteTab.value.trim(),
+        logo: siteLogo.value.trim(),
+        favicon: siteFavicon.value.trim()
       });
-      toast('Profile saved.');
+      toast('Site saved.');
     }catch(e){ toast('Save failed: ' + e); }
   }
 
-  async function handleUploadAvatar(){
+  async function handleUploadLogo(){
     try{
-      const f = avatarFile.files[0];
+      const f = logoFile.files[0];
       if(!f) return toast('Choose a file first.');
       const up = await uploadFile(f);
-      siteAvatar.value = up.url;
-      toast('Uploaded. Avatar URL set.');
+      siteLogo.value = up.url;
+      toast('Uploaded. Logo URL set.');
+    }catch(e){ toast('Upload failed: ' + e); }
+  }
+
+  async function handleUploadFavicon(){
+    try{
+      const f = faviconFile.files[0];
+      if(!f) return toast('Choose a file first.');
+      const up = await uploadFile(f);
+      siteFavicon.value = up.url;
+      toast('Uploaded. Favicon URL set.');
     }catch(e){ toast('Upload failed: ' + e); }
   }
 
   $('#save-site').onclick = handleSaveSite;
-  uploadAvatarBtn.onclick = handleUploadAvatar;
+  uploadLogoBtn.onclick = handleUploadLogo;
+  uploadFaviconBtn.onclick = handleUploadFavicon;
 
   // ====== Post creation handlers ======
   let attachedImages = [];
@@ -328,9 +343,10 @@
   // ====== Loaders ======
   async function loadSite(){
     const site = await fetchJSON('/api/site');
-    siteTitle.value = site.title || '';
-    siteDesc.value  = site.description || '';
-    siteAvatar.value= site.avatar || '';
+    siteTitle.value   = site.title || '';
+    siteTab.value     = site.tab_text || '';
+    siteLogo.value    = site.logo || '';
+    siteFavicon.value = site.favicon || '';
   }
 
   async function loadPosts(){

--- a/static/index.html
+++ b/static/index.html
@@ -3,23 +3,23 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Shawn — Portfolio</title>
-  <meta name="description" content="Shawn's personal page of photos, notes, videos, and links."/>
+  <title>Antisocial</title>
+  <link id="site-favicon" rel="icon" href="/static/favicon.ico"/>
   <link rel="stylesheet" href="/static/styles.css"/>
 </head>
 <body>
-  <section class="profile-section">
+  <header class="top-bar">
     <div class="container">
-      <div class="intro">
-        <img class="avatar" src="/static/me.jpg" alt="Shawn">
-        <div>
-          <h1>Shawn</h1>
-          <p class="muted">Senior Technical Product Specialist. Sharing photos, notes, videos, and interesting links.</p>
-        </div>
+      <div class="logo-wrap">
+        <img id="site-logo" class="logo" alt=""/>
+        <h1 id="site-title"></h1>
       </div>
-      <div id="auth-bar"></div>
+      <div class="actions">
+        <button id="btn-new-post" class="btn" style="display:none;">New Post</button>
+        <div id="auth-bar"></div>
+      </div>
     </div>
-  </section>
+  </header>
 
   <header class="site-header">
     <div class="container">
@@ -96,12 +96,8 @@
   </div>
 
   <footer class="container footer">
-    <span class="muted">© <span id="year"></span> Shawn</span>
+    <span class="muted">© <span id="year"></span> <span id="footer-title"></span></span>
   </footer>
-
-  <button id="btn-new-post" class="floating-btn" title="New post" aria-label="New post">
-    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
-  </button>
 
 <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js" defer></script>

--- a/static/styles.css
+++ b/static/styles.css
@@ -30,38 +30,69 @@ body {
 .muted { color: var(--muted); }
 
 /* Header and toolbar */
-.profile-section {
-  padding: 40px 0;
+.top-bar {
+  padding: 8px 0;
   border-bottom: 1px solid #1b2430;
   margin-bottom: 8px;
 }
-.site-header { padding: 8px 0 10px; }
-.intro {
-  display: grid;
-  grid-template-columns: 104px 1fr; /* larger avatar */
-  gap: 24px;
+.top-bar .container {
+  display: flex;
   align-items: center;
+  justify-content: space-between;
 }
-.avatar {
-  width: 104px; height: 104px; border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid #18202c;
-  box-shadow:
-    0 0 0 4px #0f1622,                 /* inner ring */
-    0 0 0 8px rgba(78,166,255,.28),    /* glow ring */
-    0 14px 28px rgba(0,0,0,.45);       /* soft drop */
+.logo-wrap {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
-.intro h1 {
-  margin: 0 0 2px 0;
-  font-size: clamp(22px, 2vw + 14px, 32px);
-  letter-spacing: -0.01em;
-  font-weight: 800;
+.logo-wrap h1 { margin: 0; font-size: 24px; }
+.logo { height: 48px; }
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
-.intro .muted {
-  color: var(--muted);
-  max-width: 70ch;
-  line-height: 1.55;
+#btn-new-post {
+  background: var(--brand);
+  border: none;
+  color: #000;
+  border-radius: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
 }
+.user-menu { position: relative; }
+.user-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+}
+.user-btn img { width: 32px; height: 32px; border-radius: 50%; }
+.dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: var(--panel);
+  border:1px solid #1b2430;
+  border-radius: 8px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 10;
+}
+.dropdown a {
+  color: var(--text);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.dropdown a:hover { color: var(--brand); }
+.hidden { display: none; }
+
+.site-header { padding: 8px 0 10px; }
 
 /* Toolbar */
 .toolbar {
@@ -405,10 +436,6 @@ body {
 .footer { padding-bottom: 40px; }
 
 /* Added for user accounts and posting */
-#auth-bar {
-  text-align: right;
-  margin-top: 8px;
-}
 #auth-bar a { color: var(--brand); text-decoration: none; }
 #auth-bar .login-btn {
   display: inline-flex;
@@ -424,35 +451,9 @@ body {
   width: 20px;
   height: 20px;
 }
-#auth-bar .user-info {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-#auth-bar .user-info img {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-}
 .author { font-size: 14px; }
 .comment-count { font-size: 14px; margin-top: 4px; }
-.floating-btn {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  border: none;
-  background: var(--brand);
-  color: #000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
 
-.floating-btn svg { width: 24px; height: 24px; }
 
 /* New post form (shared with admin) */
 .panel { background: var(--panel); border:1px solid #1b2430; border-radius:14px; }


### PR DESCRIPTION
## Summary
- Replace profile header with site logo, optional title, and top-bar post button
- Add user dropdown with profile/admin/logout and move post creation to header
- Allow admins to configure site logo, favicon, and browser tab text

## Testing
- `python -m py_compile server.py`
- `node --check static/app.js`
- `node --check static/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68b70c06e394832a9916adf28542c088