### PR TITLE
Refactor server into modular helpers

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,29 @@
+"""Authentication helpers for session management and admin checks."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from flask import Request, session
+
+from storage import load_users
+
+ADMIN_SECRET = os.environ.get("ADMIN_SECRET", "changeme")  # set real value in env!
+
+
+def current_user() -> Optional[dict]:
+    uid = session.get("uid")
+    if not uid:
+        return None
+    for user in load_users():
+        if user.get("id") == uid:
+            return user
+    return None
+
+
+def require_admin(req: Request) -> bool:
+    user = current_user()
+    if user and user.get("is_admin"):
+        return True
+    secret = req.headers.get("X-Admin-Secret") or req.args.get("key")
+    return secret == ADMIN_SECRET

--- a/storage.py
+++ b/storage.py
@@ -1,0 +1,40 @@
+"""Data storage helpers for posts, users and site metadata."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from utils import load_json, atomic_write
+
+POSTS_FILE = "posts/posts.json"
+SITE_FILE = "posts/site.json"
+USERS_FILE = "users/users.json"
+
+
+def load_posts() -> List[Dict[str, Any]]:
+    data = load_json(POSTS_FILE, {"posts": []})
+    posts = data.get("posts", [])
+    return sorted(posts, key=lambda p: p.get("date", ""), reverse=True)
+
+
+def save_posts(posts: List[Dict[str, Any]]) -> None:
+    atomic_write(POSTS_FILE, {"posts": posts})
+
+
+def load_site() -> Dict[str, Any]:
+    return load_json(
+        SITE_FILE,
+        {"title": "Antisocial", "logo": None, "favicon": None, "tab_text": "Antisocial"},
+    )
+
+
+def save_site(site: Dict[str, Any]) -> None:
+    atomic_write(SITE_FILE, site)
+
+
+def load_users() -> List[Dict[str, Any]]:
+    data = load_json(USERS_FILE, {"users": []})
+    return data.get("users", [])
+
+
+def save_users(users: List[Dict[str, Any]]) -> None:
+    atomic_write(USERS_FILE, {"users": users})

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,49 @@
+"""Utility functions for JSON handling and content detection."""
+import json
+import os
+import re
+import tempfile
+from typing import Any, Dict, List, Optional
+
+YOUTUBE_PATTERNS = [
+    r"(?:https?://)?(?:www\.)?youtube\.com/watch\?v=([A-Za-z0-9_\-]{6,})",
+    r"(?:https?://)?(?:www\.)?youtu\.be/([A-Za-z0-9_\-]{6,})",
+]
+
+
+def load_json(path: str, default: Any) -> Any:
+    """Load JSON data from *path* or return *default* if the file is missing."""
+    if not os.path.exists(path):
+        return default
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def atomic_write(path: str, data_obj: Any) -> None:
+    """Atomically write *data_obj* as JSON to *path*."""
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        dir=os.path.dirname(path), prefix=".tmp-", suffix=".json"
+    )
+    with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+        json.dump(data_obj, f, ensure_ascii=False, indent=2)
+    os.replace(tmp_path, path)
+
+
+def find_comment(comments: List[Dict[str, Any]], cid: str) -> Optional[Dict[str, Any]]:
+    """Recursively search *comments* for a comment with id *cid*."""
+    for comment in comments:
+        if comment.get("id") == cid:
+            return comment
+        found = find_comment(comment.get("replies", []), cid)
+        if found:
+            return found
+    return None
+
+
+def is_youtube(url: str) -> Optional[str]:
+    """Return the YouTube video ID if *url* is a YouTube link."""
+    for pattern in YOUTUBE_PATTERNS:
+        match = re.search(pattern, url)
+        if match:
+            return match.group(1)
+    return None


### PR DESCRIPTION
## Summary
- Extract JSON utilities, content detection, and comment lookup into `utils`
- Separate data persistence into `storage` and auth helpers into `auth`
- Simplify `server.py` to use new modules and shared comment search

## Testing
- `python -m py_compile server.py auth.py storage.py utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b72ad07064832a8c33c75d2b8dfd80